### PR TITLE
DP-1239 - Add version input to docker image actions

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -23,6 +23,7 @@ jobs:
       docker_file: noetic/Dockerfile
       docker_image: devops/ros-tools-noetic
       deploy: ${{ contains(github.ref, 'refs/heads/main') || contains(github.ref, 'refs/tags/v')}}
+      version: ${GITHUB_REF##*/}
       push_latest: ${{ contains(github.ref, 'refs/heads/main') || contains(github.ref, 'refs/tags/v') }}
       snyk_check: true
     secrets:
@@ -39,6 +40,7 @@ jobs:
       public: true
       public_image: ce/ros-tools-ce
       deploy: ${{ contains(github.ref, 'refs/heads/main') || contains(github.ref, 'refs/tags/v')}}
+      version: ${GITHUB_REF##*/}
       push_latest: ${{ contains(github.ref, 'refs/heads/main') || contains(github.ref, 'refs/tags/v') }}
       snyk_check: true
     secrets:


### PR DESCRIPTION
Add 'version' input to docker image action.

Pipeline Run: https://github.com/MOV-AI/containers-ros-tools/actions/runs/5764742800

Tag Version Generated: merge (as determined before by the github reference context)
Push Flag: False

---------------------------

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository
