### PR TITLE
Release dependencies update

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: '0'
     - name: Bump version and push tag

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -11,7 +11,7 @@ jobs:
       with:
         fetch-depth: '0'
     - name: Bump version and push tag
-      uses: anothrNick/github-tag-action@1.61.0
+      uses: anothrNick/github-tag-action@1.64.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         WITH_V: true

--- a/ce/Dockerfile
+++ b/ce/Dockerfile
@@ -1,6 +1,6 @@
 # This Dockerfile is used to build an rviz image based on Ubuntu
 ARG DOCKER_REGISTRY="pubregistry.aws.cloud.mov.ai"
-FROM ${DOCKER_REGISTRY}/ce/movai-base-focal:v2.4.3
+FROM ${DOCKER_REGISTRY}/ce/movai-base-focal:v2.4.4
 
 LABEL description="MOV.AI Graphical Tools"
 LABEL maintainer="devops@mov.ai"

--- a/noetic/Dockerfile
+++ b/noetic/Dockerfile
@@ -1,6 +1,6 @@
 # This Dockerfile is used to build an headless vnc image based on Ubuntu
 ARG DOCKER_REGISTRY="pubregistry.aws.cloud.mov.ai"
-FROM ${DOCKER_REGISTRY}/ce/movai-base-focal:v2.4.3
+FROM ${DOCKER_REGISTRY}/ce/movai-base-focal:v2.4.4
 
 LABEL description="MOV.AI Graphical Tools"
 LABEL maintainer="devops@mov.ai"


### PR DESCRIPTION
DP-1279 : propagate the APT repo used for archive of disappeared packages